### PR TITLE
Add failing increment_after_colon test

### DIFF
--- a/tests/increment_testfile.py
+++ b/tests/increment_testfile.py
@@ -5,6 +5,19 @@ def test_increment():
     a++
     assert a == 1
 
+# This test won't even run, as var++ after the colon fails to parse
+# correctly and is considered invalid syntax.
+def test_increment_after_colon():
+    this_works = 0
+    for _ in range(3): this_works += 1
+    if True: this_works += 1
+    assert this_works == 4
+
+    this_fails = 0
+    for _ in range(3): this_fails++
+    if True: this_fails++
+    assert this_fails == 4
+
 if __name__ == "__main__":
     test_increment()
     print("Success.")


### PR DESCRIPTION
It's legal in Python to put a statement on the same line after the
colon of statements like `for`, `if`, `while`, etc. In this
circumstance, the experimental increment operator fails to parse. I
have no fix for this issue, but here is a simple test case.
Unfortunately, the test can't actually be run, since the syntax it
would check is not legal.